### PR TITLE
memcache: instrument for tracing and metrics with OpenCensus

### DIFF
--- a/memcache/memcache_test.go
+++ b/memcache/memcache_test.go
@@ -19,6 +19,7 @@ package memcache
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -71,9 +72,9 @@ func TestUnixSocket(t *testing.T) {
 	testWithClient(t, New(sock))
 }
 
-func mustSetF(t *testing.T, c *Client) func(*Item) {
+func mustSetF(t *testing.T, ctx context.Context, c *Client) func(*Item) {
 	return func(it *Item) {
-		if err := c.Set(it); err != nil {
+		if err := c.Set(ctx, it); err != nil {
 			t.Fatalf("failed to Set %#v: %v", *it, err)
 		}
 	}
@@ -85,17 +86,18 @@ func testWithClient(t *testing.T, c *Client) {
 			t.Fatalf(format, args...)
 		}
 	}
-	mustSet := mustSetF(t, c)
+	ctx := context.Background()
+	mustSet := mustSetF(t, ctx, c)
 
 	// Set
 	foo := &Item{Key: "foo", Value: []byte("fooval"), Flags: 123}
-	err := c.Set(foo)
+	err := c.Set(ctx, foo)
 	checkErr(err, "first set(foo): %v", err)
-	err = c.Set(foo)
+	err = c.Set(ctx, foo)
 	checkErr(err, "second set(foo): %v", err)
 
 	// Get
-	it, err := c.Get("foo")
+	it, err := c.Get(ctx, "foo")
 	checkErr(err, "get(foo): %v", err)
 	if it.Key != "foo" {
 		t.Errorf("get(foo) Key = %q, want foo", it.Key)
@@ -110,9 +112,9 @@ func testWithClient(t *testing.T, c *Client) {
 	// Get and set a unicode key
 	quxKey := "Hello_世界"
 	qux := &Item{Key: quxKey, Value: []byte("hello world")}
-	err = c.Set(qux)
+	err = c.Set(ctx, qux)
 	checkErr(err, "first set(Hello_世界): %v", err)
-	it, err = c.Get(quxKey)
+	it, err = c.Get(ctx, quxKey)
 	checkErr(err, "get(Hello_世界): %v", err)
 	if it.Key != quxKey {
 		t.Errorf("get(Hello_世界) Key = %q, want Hello_世界", it.Key)
@@ -123,34 +125,34 @@ func testWithClient(t *testing.T, c *Client) {
 
 	// Set malformed keys
 	malFormed := &Item{Key: "foo bar", Value: []byte("foobarval")}
-	err = c.Set(malFormed)
+	err = c.Set(ctx, malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo bar) should return ErrMalformedKey instead of %v", err)
 	}
 	malFormed = &Item{Key: "foo" + string(0x7f), Value: []byte("foobarval")}
-	err = c.Set(malFormed)
+	err = c.Set(ctx, malFormed)
 	if err != ErrMalformedKey {
 		t.Errorf("set(foo<0x7f>) should return ErrMalformedKey instead of %v", err)
 	}
 
 	// Add
 	bar := &Item{Key: "bar", Value: []byte("barval")}
-	err = c.Add(bar)
+	err = c.Add(ctx, bar)
 	checkErr(err, "first add(foo): %v", err)
-	if err := c.Add(bar); err != ErrNotStored {
+	if err := c.Add(ctx, bar); err != ErrNotStored {
 		t.Fatalf("second add(foo) want ErrNotStored, got %v", err)
 	}
 
 	// Replace
 	baz := &Item{Key: "baz", Value: []byte("bazvalue")}
-	if err := c.Replace(baz); err != ErrNotStored {
+	if err := c.Replace(ctx, baz); err != ErrNotStored {
 		t.Fatalf("expected replace(baz) to return ErrNotStored, got %v", err)
 	}
-	err = c.Replace(bar)
+	err = c.Replace(ctx, bar)
 	checkErr(err, "replaced(foo): %v", err)
 
 	// GetMulti
-	m, err := c.GetMulti([]string{"foo", "bar"})
+	m, err := c.GetMulti(ctx, []string{"foo", "bar"})
 	checkErr(err, "GetMulti: %v", err)
 	if g, e := len(m), 2; g != e {
 		t.Errorf("GetMulti: got len(map) = %d, want = %d", g, e)
@@ -169,42 +171,42 @@ func testWithClient(t *testing.T, c *Client) {
 	}
 
 	// Delete
-	err = c.Delete("foo")
+	err = c.Delete(ctx, "foo")
 	checkErr(err, "Delete: %v", err)
-	it, err = c.Get("foo")
+	it, err = c.Get(ctx, "foo")
 	if err != ErrCacheMiss {
 		t.Errorf("post-Delete want ErrCacheMiss, got %v", err)
 	}
 
 	// Incr/Decr
 	mustSet(&Item{Key: "num", Value: []byte("42")})
-	n, err := c.Increment("num", 8)
+	n, err := c.Increment(ctx, "num", 8)
 	checkErr(err, "Increment num + 8: %v", err)
 	if n != 50 {
 		t.Fatalf("Increment num + 8: want=50, got=%d", n)
 	}
-	n, err = c.Decrement("num", 49)
+	n, err = c.Decrement(ctx, "num", 49)
 	checkErr(err, "Decrement: %v", err)
 	if n != 1 {
 		t.Fatalf("Decrement 49: want=1, got=%d", n)
 	}
-	err = c.Delete("num")
+	err = c.Delete(ctx, "num")
 	checkErr(err, "delete num: %v", err)
-	n, err = c.Increment("num", 1)
+	n, err = c.Increment(ctx, "num", 1)
 	if err != ErrCacheMiss {
 		t.Fatalf("increment post-delete: want ErrCacheMiss, got %v", err)
 	}
 	mustSet(&Item{Key: "num", Value: []byte("not-numeric")})
-	n, err = c.Increment("num", 1)
+	n, err = c.Increment(ctx, "num", 1)
 	if err == nil || !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("increment non-number: want client error, got %v", err)
 	}
 	testTouchWithClient(t, c)
 
 	// Test Delete All
-	err = c.DeleteAll()
+	err = c.DeleteAll(ctx)
 	checkErr(err, "DeleteAll: %v", err)
-	it, err = c.Get("bar")
+	it, err = c.Get(ctx, "bar")
 	if err != ErrCacheMiss {
 		t.Errorf("post-DeleteAll want ErrCacheMiss, got %v", err)
 	}
@@ -217,7 +219,8 @@ func testTouchWithClient(t *testing.T, c *Client) {
 		return
 	}
 
-	mustSet := mustSetF(t, c)
+	ctx := context.Background()
+	mustSet := mustSetF(t, ctx, c)
 
 	const secondsToExpiry = int32(2)
 
@@ -233,13 +236,13 @@ func testTouchWithClient(t *testing.T, c *Client) {
 
 	for s := 0; s < 3; s++ {
 		time.Sleep(time.Duration(1 * time.Second))
-		err := c.Touch(foo.Key, secondsToExpiry)
+		err := c.Touch(ctx, foo.Key, secondsToExpiry)
 		if nil != err {
 			t.Errorf("error touching foo: %v", err.Error())
 		}
 	}
 
-	_, err := c.Get("foo")
+	_, err := c.Get(ctx, "foo")
 	if err != nil {
 		if err == ErrCacheMiss {
 			t.Fatalf("touching failed to keep item foo alive")
@@ -248,7 +251,7 @@ func testTouchWithClient(t *testing.T, c *Client) {
 		}
 	}
 
-	_, err = c.Get("bar")
+	_, err = c.Get(ctx, "bar")
 	if nil == err {
 		t.Fatalf("item bar did not expire within %v seconds", time.Now().Sub(setTime).Seconds())
 	} else {
@@ -259,6 +262,7 @@ func testTouchWithClient(t *testing.T, c *Client) {
 }
 
 func BenchmarkOnItem(b *testing.B) {
+	b.ReportAllocs()
 	fakeServer, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		b.Fatal("Could not open fake server: ", err)
@@ -274,16 +278,17 @@ func BenchmarkOnItem(b *testing.B) {
 		}
 	}()
 
+	ctx := context.Background()
 	addr := fakeServer.Addr()
 	c := New(addr.String())
-	if _, err := c.getConn(addr); err != nil {
+	if _, err := c.getConn(ctx, addr); err != nil {
 		b.Fatal("failed to initialize connection to fake server")
 	}
 
 	item := Item{Key: "foo"}
-	dummyFn := func(_ *Client, _ *bufio.ReadWriter, _ *Item) error { return nil }
+	dummyFn := func(_ *Client, _ context.Context, _ *bufio.ReadWriter, _ *Item) error { return nil }
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		c.onItem(&item, dummyFn)
+		c.onItem(ctx, &item, dummyFn)
 	}
 }

--- a/memcache/stats.go
+++ b/memcache/stats.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2018 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memcache
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+const unitDimensionless = "1"
+
+var (
+	// Stats
+	mCacheMisses     = stats.Int64("cache_misses", "Number of cache misses", unitDimensionless)
+	mCacheHits       = stats.Int64("cache_hits", "Number of cache hits", unitDimensionless)
+	mClientErrors    = stats.Int64("client_errors", "Number of general client errors", unitDimensionless)
+	mParseErrors     = stats.Int64("parse_errors", "Number of errors encountered while parsing", unitDimensionless)
+	mIllegalKeys     = stats.Int64("illegal_key", "Number of illegal keys", unitDimensionless)
+	mCASConflicts    = stats.Int64("cas_conflicts", "Number of CAS conflicts", unitDimensionless)
+	mUnstoredResults = stats.Int64("unstored_results", "Number of unstored results", unitDimensionless)
+	mDialErrors      = stats.Int64("dial_errors", "Number of dial errors", unitDimensionless)
+
+	mFlushAll       = stats.Int64("flushall", "Number of FlushAll invocations", unitDimensionless)
+	mGet            = stats.Int64("get", "Number of Get invocations", unitDimensionless)
+	mTouch          = stats.Int64("touch", "Number of Touch invocations", unitDimensionless)
+	mKeyLength      = stats.Int64("key_length", "Measures the length of keys", unitDimensionless)
+	mValueLength    = stats.Int64("key_length", "Measures the length of values", unitDimensionless)
+	mSet            = stats.Int64("set", "Number of Set invocations", unitDimensionless)
+	mAdd            = stats.Int64("add", "Number of Add invocations", unitDimensionless)
+	mDelete         = stats.Int64("delete", "Number of Delete invocations", unitDimensionless)
+	mDeleteAll      = stats.Int64("deleteall", "Number of DeleteAll invocations", unitDimensionless)
+	mDelta          = stats.Int64("delta", "Number of Delta invocations", unitDimensionless)
+	mCompareAndSwap = stats.Int64("delta", "Number of Delta invocations", unitDimensionless)
+	mReplace        = stats.Int64("replace ", "Number of Replace invocations", unitDimensionless)
+	mDecrement      = stats.Int64("decrement", "Number of Decrement invocations", unitDimensionless)
+	mIncrement      = stats.Int64("increment", "Number of Increment invocations", unitDimensionless)
+
+	// Views
+	AllViews = []*view.View{
+		{
+			Name:        "gomemcache/cache_hits",
+			Description: "Number of cache hits",
+			Measure:     mCacheHits,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/cache_misses",
+			Description: "Number of cache misses",
+			Measure:     mCacheMisses,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/client_errors",
+			Description: "Number of general client errors",
+			Measure:     mClientErrors,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/parse_errors",
+			Description: "Number of errors encountered while parsing",
+			Measure:     mParseErrors,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/illegal_keys",
+			Description: "Number of illegal keys encountered",
+			Measure:     mIllegalKeys,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/cas_conflicts",
+			Description: "Number of CAS conflicts encountered",
+			Measure:     mCASConflicts,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/unstored_results",
+			Description: "Number of unstored results",
+			Measure:     mUnstoredResults,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/dial_errors",
+			Description: "Number of dial errors",
+			Measure:     mDialErrors,
+			Aggregation: view.Count(),
+		},
+
+		{
+			Name:        "gomemcache/flushall",
+			Description: "Number of FlushAll invocations",
+			Measure:     mFlushAll,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/get",
+			Description: "Number of Get invocations",
+			Measure:     mGet,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/touch",
+			Description: "Number of Touch invocations",
+			Measure:     mTouch,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/key_length",
+			Description: "The distribution of the lengths of keys",
+			Measure:     mKeyLength,
+			// The longest memcache key is 255
+			Aggregation: view.Distribution(0, 20, 40, 80, 100, 120, 140, 160, 180, 200, 220, 240, 260),
+		},
+		{
+			Name:        "gomemcache/value_length",
+			Description: "The distribution of the lengths of values",
+			Measure:     mValueLength,
+			Aggregation: view.Distribution(
+				0, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288,
+				1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728, 268435456,
+				536870912, 1073741824, 2147483648, 4294967296, 8589934592, 17179869184, 34359738368,
+				68719476736, 137438953472, 274877906944, 549755813888, 1099511627776, 2199023255552,
+				4398046511104, 8796093022208, 17592186044416, 35184372088832, 70368744177664, 140737488355328,
+				281474976710656, 562949953421312, 1125899906842624, 2251799813685248, 4503599627370496,
+				9007199254740992, 18014398509481984, 36028797018963968, 72057594037927936, 144115188075855872,
+				288230376151711744, 576460752303423488, 1152921504606846976, 2305843009213693952, 4611686018427387904,
+				9223372036854775808,
+			),
+		},
+		{
+			Name:        "gomemcache/set",
+			Description: "Number of Set invocations",
+			Measure:     mSet,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/add",
+			Description: "Number of Add invocations",
+			Measure:     mSet,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/delete",
+			Description: "Number of Delete invocations",
+			Measure:     mDelete,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/replace",
+			Description: "Number of Replace invocations",
+			Measure:     mReplace,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/cas",
+			Description: "Number of CompareAndSwap invocations",
+			Measure:     mCompareAndSwap,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/delta",
+			Description: "The distribution of deltas used",
+			Measure:     mDelta,
+			Aggregation: view.Distribution(0, 25, 50, 100, 200, 250, 400, 500, 800, 1000, 1400, 1600, 3200, 5000, 10000, 100000, 1000000),
+		},
+		{
+			Name:        "gomemcache/deleteall",
+			Description: "Number of DeleteAll invocations",
+			Measure:     mDeleteAll,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/decrement",
+			Description: "Number of Decrement invocations",
+			Measure:     mDecrement,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        "gomemcache/inccrement",
+			Description: "Number of Increment invocations",
+			Measure:     mIncrement,
+			Aggregation: view.Count(),
+		},
+	}
+)


### PR DESCRIPTION
Given

### Request
```shell
curl -X POST http://localhost:8778/fetch --data '{"url": "https://en.wikipedia.org?lang=foo"}'
```
Source code:

### Server
https://gist.github.com/odeke-em/7d128bed37c4e6da328895566514e50d#file-server-go

### Prometheus configuration file
https://gist.github.com/odeke-em/7d128bed37c4e6da328895566514e50d#file-prometheus-yml

## Metrics & Monitoring

##### Google Stackdriver Monitoring
![screen shot 2018-04-28 at 9 58 22 pm](https://user-images.githubusercontent.com/4898263/39403375-60b10d2c-4b2f-11e8-915a-23839684b069.png)

##### Prometheus
![screen shot 2018-04-28 at 9 58 46 pm](https://user-images.githubusercontent.com/4898263/39403374-609dcc44-4b2f-11e8-986d-898c981a5867.png)

## Tracing
### On cache hit
##### Seen on AWS X-Ray Tracing
![screen shot 2018-04-28 at 10 00 46 pm](https://user-images.githubusercontent.com/4898263/39403393-c30d3c7a-4b2f-11e8-8ba3-f4ff6b81669a.png)

##### Seen on Google Stackdriver Tracing
![screen shot 2018-04-28 at 10 01 23 pm](https://user-images.githubusercontent.com/4898263/39403392-c2f942a6-4b2f-11e8-8003-1d3d086972f6.png)

### On cache miss
![screen shot 2018-04-28 at 9 58 07 pm](https://user-images.githubusercontent.com/4898263/39403376-60c2b57c-4b2f-11e8-9616-3d538d97fd54.png)
![screen shot 2018-04-28 at 9 57 45 pm](https://user-images.githubusercontent.com/4898263/39403378-6b841546-4b2f-11e8-9f82-45253b37a802.png)
